### PR TITLE
Adding features to control if the macro uses `env_logger` or `tracing` and allow more flexibility around logging initialization/configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1369,6 +1371,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1416,12 @@ name = "outref"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460b31760eb56186dc8006c41b807a59c25dda5aad08eb90c55d84d19e8aff40"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -1797,6 +1815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2135,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,14 +2162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -2290,9 +2328,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
-version = "0.3.0"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ad91d846a4a5342c1fb7008d26124ee6cf94a3953751618577295373b32117"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -2300,15 +2338,15 @@ dependencies = [
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16a8e2ebfc883e2b1771c6482b1fb3c6831eab289ba391619a2d93a7356220f"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca29cb03c8ceaf20f8224a18a530938305e9872b1478ea24ff44b4f503a1d1d"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincolor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.52",
+ "tracing",
  "trybuild",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,19 @@ tokio = { version = "1", features = ["macros"] }
 lambda_runtime = "1.0"
 aws-config = { version = "1.5", features = ["behavior-version-latest"] }
 aws-smithy-types = "1.3"
-log = "0.4"
-env_logger = "0.11"
 thiserror = "1.0"
 uuid = { version = "1.11", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+# Default Lambda logging is based on log/env_logger
+log = { version = "0.4"}
+env_logger = { version = "0.11" }
+
+# Alternatively, a feature allow the use of tracing/tracing-subscriber
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+
 
 # Proc-macro crate dependencies
 syn = { version = "2.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Default Lambda logging is based on log/env_logger
-log = { version = "0.4"}
-env_logger = { version = "0.11" }
+log = "0.4"
+env_logger = "0.11"
 
 # Alternatively, a feature allow the use of tracing/tracing-subscriber
-tracing = { version = "0.1" }
+tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 

--- a/lambda-appsync-proc/Cargo.toml
+++ b/lambda-appsync-proc/Cargo.toml
@@ -22,7 +22,13 @@ graphql-parser = { workspace = true }
 
 [dev-dependencies]
 lambda-appsync = { path = "../lambda-appsync", default-features = false, features = ["env_logger", "tracing"] }
+tracing = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
 serde = { workspace = true }
 trybuild = { workspace = true }
+
+[features]
+default = ["env_logger", "tracing"]
+env_logger = []
+tracing = []

--- a/lambda-appsync-proc/Cargo.toml
+++ b/lambda-appsync-proc/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = { workspace = true }
 graphql-parser = { workspace = true }
 
 [dev-dependencies]
-lambda-appsync = { path = "../lambda-appsync", default-features = false, features = ["env_logger", "tracing"] }
+lambda-appsync = { path = "../lambda-appsync", default-features = false, features = ["log", "env_logger", "tracing"] }
 tracing = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
@@ -29,6 +29,7 @@ serde = { workspace = true }
 trybuild = { workspace = true }
 
 [features]
-default = ["env_logger", "tracing"]
+default = ["log", "env_logger", "tracing"]
+log = []
 env_logger = []
 tracing = []

--- a/lambda-appsync-proc/Cargo.toml
+++ b/lambda-appsync-proc/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = { workspace = true }
 graphql-parser = { workspace = true }
 
 [dev-dependencies]
-lambda-appsync = { path = "../lambda-appsync" }
+lambda-appsync = { path = "../lambda-appsync", default-features = false, features = ["env_logger", "tracing"] }
 aws-sdk-s3 = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
 serde = { workspace = true }

--- a/lambda-appsync-proc/src/appsync_lambda_main/graphql.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/graphql.rs
@@ -976,13 +976,9 @@ impl GraphQLSchema {
 
         #[allow(unused_mut)]
         let mut log_lines = proc_macro2::TokenStream::new();
-        #[cfg(feature = "env_logger")]
+        #[cfg(feature = "log")]
         log_lines.extend(quote_spanned! {span=>
             ::lambda_appsync::log::error!("{e}");
-        });
-        #[cfg(feature = "tracing")]
-        log_lines.extend(quote_spanned! {span=>
-            ::lambda_appsync::tracing::error!("{e}");
         });
 
         tokens.extend(quote_spanned! {span=>

--- a/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
@@ -476,8 +476,12 @@ impl AppsyncLambdaMain {
             let mut default_log_init = proc_macro2::TokenStream::new();
             #[cfg(feature = "env_logger")]
             default_log_init.extend(Self::default_env_logger_init());
-            #[cfg(feature = "tracing")]
+            // The code initializing tracing fails if the env_logger initialization already happened
+            #[cfg(all(feature = "tracing", not(any(feature = "env_logger"))))]
             default_log_init.extend(Self::default_tracing_init());
+            // Future default inits can be inserted here like that for feature "fastrace" (for example):
+            // #[cfg(all(feature = "fastrace", not(any(feature = "env_logger", feature = "tracing"))))]
+            // default_log_init.extend(Self::default_fastrace_init());
             default_log_init
         };
 

--- a/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
@@ -504,12 +504,12 @@ impl AppsyncLambdaMain {
         let log_init = TokenStream2::new();
 
         #[allow(unused_mut)]
-        let mut bing_in_scope = TokenStream2::new();
-        bing_in_scope.extend(quote! {
+        let mut bring_in_scope = TokenStream2::new();
+        bring_in_scope.extend(quote! {
             use ::lambda_appsync::tokio;
         });
         #[cfg(feature = "tracing")]
-        bing_in_scope.extend(quote! {
+        bring_in_scope.extend(quote! {
             use ::lambda_appsync::tracing;
         });
 
@@ -519,7 +519,7 @@ impl AppsyncLambdaMain {
 
             #(#aws_client_getters)*
 
-            #bing_in_scope
+            #bring_in_scope
 
             #[tokio::main]
             async fn main() -> ::core::result::Result<(), ::lambda_appsync::lambda_runtime::Error> {

--- a/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
@@ -383,7 +383,7 @@ impl AppsyncLambdaMain {
                     .json()
                     .with_env_filter(
                         ::lambda_appsync::tracing_subscriber::EnvFilter::from_default_env()
-                            .add_directive(tracing::Level::INFO.into()),
+                            .add_directive(::lambda_appsync::tracing::Level::INFO.into()),
                     )
                     // this needs to be set to remove duplicated information in the log.
                     .with_current_span(false)

--- a/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
@@ -170,7 +170,7 @@ impl Default for OptionalParameters {
             hook: None,
             log_init: None,
             #[cfg(feature = "log")]
-            event_logging: true,
+            event_logging: false,
             tos: TypeOverrides::new(),
             nos: NameOverrides::new(),
         }
@@ -329,7 +329,7 @@ impl AppsyncLambdaMain {
         #[cfg(feature = "log")]
         if self.options.event_logging {
             log_lines.extend(quote! {
-                ::lambda_appsync::log::info!("event={event:?}");
+                ::lambda_appsync::log::debug!("event={event:?}");
             });
         }
         #[cfg(feature = "log")]
@@ -450,8 +450,7 @@ impl AppsyncLambdaMain {
         #[cfg(feature = "log")]
         if self.options.event_logging {
             log_lines.extend(quote! {
-                ::lambda_appsync::log::debug!("{event:?}");
-                ::lambda_appsync::log::info!("{}", ::lambda_appsync::serde_json::json!(event.payload));
+                ::lambda_appsync::log::debug!("{}", ::lambda_appsync::serde_json::json!(event.payload));
             });
         }
 

--- a/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
@@ -408,8 +408,6 @@ impl AppsyncLambdaMain {
                     // this needs to be set to false, otherwise ANSI color codes will
                     // show up in a confusing manner in CloudWatch logs.
                     .with_ansi(false)
-                    // disabling time is handy because CloudWatch will add the ingestion time.
-                    .without_time()
                     // remove the name of the function from every log entry
                     .with_target(false)
                     .init();

--- a/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
+++ b/lambda-appsync-proc/src/appsync_lambda_main/mod.rs
@@ -70,7 +70,6 @@ enum OptionalParameter {
     ExcludeAppsyncOperations(bool),
     OnlyAppsyncOperations(bool),
     Hook(Ident),
-    #[cfg(feature = "log")]
     LogInit(Ident),
     #[cfg(feature = "log")]
     EventLogging(bool),
@@ -98,7 +97,6 @@ impl Parse for OptionalParameter {
                 input.parse::<LitBool>()?.value(),
             )),
             "hook" => Ok(Self::Hook(input.parse()?)),
-            #[cfg(feature = "log")]
             "log_init" => Ok(Self::LogInit(input.parse()?)),
             #[cfg(feature = "log")]
             "event_logging" => Ok(Self::EventLogging(input.parse::<LitBool>()?.value())),
@@ -156,7 +154,6 @@ struct OptionalParameters {
     appsync_operations: bool,
     lambda_handler: bool,
     hook: Option<Ident>,
-    #[cfg(feature = "log")]
     log_init: Option<Ident>,
     #[cfg(feature = "log")]
     event_logging: bool,
@@ -171,7 +168,6 @@ impl Default for OptionalParameters {
             appsync_operations: true,
             lambda_handler: true,
             hook: None,
-            #[cfg(feature = "log")]
             log_init: None,
             #[cfg(feature = "log")]
             event_logging: true,
@@ -205,7 +201,6 @@ impl OptionalParameters {
             OptionalParameter::Hook(ident) => {
                 self.hook.replace(ident);
             }
-            #[cfg(feature = "log")]
             OptionalParameter::LogInit(ident) => {
                 self.log_init.replace(ident);
             }
@@ -478,7 +473,6 @@ impl AppsyncLambdaMain {
         };
         let aws_client_getters = self.aws_clients.iter().map(|ac| ac.aws_client_getter());
 
-        #[cfg(feature = "log")]
         let log_init = if let Some(ref log_init) = self.options.log_init {
             quote_spanned! {log_init.span()=>
                 mod _check_sig {
@@ -500,8 +494,6 @@ impl AppsyncLambdaMain {
             // default_log_init.extend(Self::default_fastrace_init());
             default_log_init
         };
-        #[cfg(not(feature = "log"))]
-        let log_init = TokenStream2::new();
 
         #[allow(unused_mut)]
         let mut bring_in_scope = TokenStream2::new();

--- a/lambda-appsync-proc/src/lib.rs
+++ b/lambda-appsync-proc/src/lib.rs
@@ -194,9 +194,6 @@ use proc_macro::TokenStream;
 ///     name_override = Player.name: email,
 ///     // Override team `PYTHON` to be `Snake` (instead of `Python`)
 ///     name_override = Team.PYTHON: Snake,
-///     name_override = WeirdFieldNames.await: no_await,
-///     name_override = WeirdFieldNames.crate: no_crate,
-///     name_override = WeirdFieldNames.u8: no_u8,
 ///     // MUST also override ALL the operations return type !!!
 ///     type_override = Query.players: NewPlayer,
 ///     type_override = Query.player: NewPlayer,

--- a/lambda-appsync-proc/src/lib.rs
+++ b/lambda-appsync-proc/src/lib.rs
@@ -30,6 +30,7 @@ use proc_macro::TokenStream;
 /// - `batch = bool`: Enable/disable batch request handling (default: true)
 /// - `hook = fn_name`: Add a custom hook function for request validation/auth
 /// - (feature: `log`) `log_init = fn_name`: Use a custom log initialization function instead of the default one
+/// - (feature: `log`) `event_logging = bool`: If true, the macro will generate code to dump the entire event in the logs (default: `true`)
 /// - `exclude_lambda_handler = bool`: Skip generation of Lambda handler code
 /// - `only_lambda_handler = bool`: Only generate Lambda handler code
 /// - `exclude_appsync_types = bool`: Skip generation of GraphQL type definitions

--- a/lambda-appsync-proc/src/lib.rs
+++ b/lambda-appsync-proc/src/lib.rs
@@ -257,8 +257,6 @@ use proc_macro::TokenStream;
 ///         // this needs to be set to false, otherwise ANSI color codes will
 ///         // show up in a confusing manner in CloudWatch logs.
 ///         .with_ansi(false)
-///         // disabling time is handy because CloudWatch will add the ingestion time.
-///         .without_time()
 ///         // remove the name of the function from every log entry
 ///         .with_target(false)
 ///         .init();

--- a/lambda-appsync-proc/src/lib.rs
+++ b/lambda-appsync-proc/src/lib.rs
@@ -29,7 +29,7 @@ use proc_macro::TokenStream;
 ///
 /// - `batch = bool`: Enable/disable batch request handling (default: true)
 /// - `hook = fn_name`: Add a custom hook function for request validation/auth
-/// - `log_init = fn_name`: Use a custom log initialization function instead of the default one
+/// - (feature: `log`) `log_init = fn_name`: Use a custom log initialization function instead of the default one
 /// - `exclude_lambda_handler = bool`: Skip generation of Lambda handler code
 /// - `only_lambda_handler = bool`: Only generate Lambda handler code
 /// - `exclude_appsync_types = bool`: Skip generation of GraphQL type definitions
@@ -239,7 +239,7 @@ use proc_macro::TokenStream;
 ///
 /// ### Feature `tracing`
 ///
-/// Alternatively, you can use the `tracing` feature so `lambda_appsync` exposes and uses `tracing` and `tracing-subscriber`
+/// Alternatively, you can use the `tracing` feature so `lambda_appsync` exposes and uses `log`, `tracing` and `tracing-subscriber`
 ///
 /// ```no_run
 /// # mod sub {

--- a/lambda-appsync-proc/src/lib.rs
+++ b/lambda-appsync-proc/src/lib.rs
@@ -29,8 +29,9 @@ use proc_macro::TokenStream;
 ///
 /// - `batch = bool`: Enable/disable batch request handling (default: true)
 /// - `hook = fn_name`: Add a custom hook function for request validation/auth
-/// - (feature: `log`) `log_init = fn_name`: Use a custom log initialization function instead of the default one
-/// - (feature: `log`) `event_logging = bool`: If true, the macro will generate code to dump the entire event in the logs (default: `true`)
+/// - `log_init = fn_name`: Use a custom log initialization function instead of the default one
+/// - (feature: `log`) `event_logging = bool`: If true, the macro will generate code to dump the
+///   lambda payload JSON as well as parsed `AppsyncEvent<Operation>`s in the logs at debug level (default: `false`)
 /// - `exclude_lambda_handler = bool`: Skip generation of Lambda handler code
 /// - `only_lambda_handler = bool`: Only generate Lambda handler code
 /// - `exclude_appsync_types = bool`: Skip generation of GraphQL type definitions

--- a/lambda-appsync-proc/tests/fail/invalid_log_init_args.rs
+++ b/lambda-appsync-proc/tests/fail/invalid_log_init_args.rs
@@ -1,0 +1,8 @@
+mod no_run {
+    fn custom_log_init(_arg: String) {
+        // Here would go custom initialization code
+    }
+    use lambda_appsync::appsync_lambda_main;
+    appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+}
+fn main() {}

--- a/lambda-appsync-proc/tests/fail/invalid_log_init_args.stderr
+++ b/lambda-appsync-proc/tests/fail/invalid_log_init_args.stderr
@@ -1,0 +1,14 @@
+error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
+ --> tests/fail/invalid_log_init_args.rs:6:67
+  |
+2 |     fn custom_log_init(_arg: String) {
+  |     -------------------------------- takes 1 argument
+...
+6 |     appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+  |                                                                   ^^^^^^^^^^^^^^^ expected function that takes 0 arguments
+  |
+note: required by a bound in `call_log_init`
+ --> tests/fail/invalid_log_init_args.rs:6:67
+  |
+6 |     appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+  |                                                                   ^^^^^^^^^^^^^^^ required by this bound in `call_log_init`

--- a/lambda-appsync-proc/tests/fail/invalid_log_init_ret.rs
+++ b/lambda-appsync-proc/tests/fail/invalid_log_init_ret.rs
@@ -1,0 +1,9 @@
+mod no_run {
+    fn custom_log_init() -> &'static str {
+        // Here would go custom initialization code
+        "some value"
+    }
+    use lambda_appsync::appsync_lambda_main;
+    appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+}
+fn main() {}

--- a/lambda-appsync-proc/tests/fail/invalid_log_init_ret.stderr
+++ b/lambda-appsync-proc/tests/fail/invalid_log_init_ret.stderr
@@ -1,0 +1,11 @@
+error[E0271]: expected `custom_log_init` to be a fn item that returns `()`, but it returns `&str`
+ --> tests/fail/invalid_log_init_ret.rs:7:67
+  |
+7 |     appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+  |                                                                   ^^^^^^^^^^^^^^^ expected `()`, found `&str`
+  |
+note: required by a bound in `call_log_init`
+ --> tests/fail/invalid_log_init_ret.rs:7:67
+  |
+7 |     appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+  |                                                                   ^^^^^^^^^^^^^^^ required by this bound in `call_log_init`

--- a/lambda-appsync-proc/tests/pass/event_logging_option.rs
+++ b/lambda-appsync-proc/tests/pass/event_logging_option.rs
@@ -1,0 +1,6 @@
+mod no_run {
+    // Test with event_logging disabled
+    lambda_appsync::appsync_lambda_main!("../../../../schema.graphql", event_logging = false);
+}
+
+fn main() {}

--- a/lambda-appsync-proc/tests/pass/event_logging_option.rs
+++ b/lambda-appsync-proc/tests/pass/event_logging_option.rs
@@ -1,6 +1,6 @@
 mod no_run {
-    // Test with event_logging disabled
-    lambda_appsync::appsync_lambda_main!("../../../../schema.graphql", event_logging = false);
+    // Test with event_logging enabled
+    lambda_appsync::appsync_lambda_main!("../../../../schema.graphql", event_logging = true);
 }
 
 fn main() {}

--- a/lambda-appsync-proc/tests/pass/log_init.rs
+++ b/lambda-appsync-proc/tests/pass/log_init.rs
@@ -1,0 +1,9 @@
+mod no_run {
+    fn custom_log_init() {
+        // Here would go custom initialization code
+    }
+    use lambda_appsync::appsync_lambda_main;
+    appsync_lambda_main!("../../../../schema.graphql", log_init = custom_log_init);
+}
+
+fn main() {}

--- a/lambda-appsync/Cargo.toml
+++ b/lambda-appsync/Cargo.toml
@@ -36,5 +36,6 @@ aws-sdk-dynamodb = { workspace = true }
 
 [features]
 default = ["env_logger"]
-env_logger = ["dep:log", "dep:env_logger", "lambda-appsync-proc/env_logger"]
-tracing = ["dep:tracing", "dep:tracing-subscriber", "lambda-appsync-proc/tracing"]
+env_logger = ["log", "dep:env_logger", "lambda-appsync-proc/env_logger"]
+tracing = ["log", "dep:tracing", "dep:tracing-subscriber", "lambda-appsync-proc/tracing"]
+log = ["dep:log", "lambda-appsync-proc/log"]

--- a/lambda-appsync/Cargo.toml
+++ b/lambda-appsync/Cargo.toml
@@ -18,12 +18,23 @@ tokio = { workspace = true }
 lambda_runtime = { workspace = true }
 aws-config = { workspace = true }
 aws-smithy-types = { workspace = true }
-log = { workspace = true }
-env_logger = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+# For feature env_logger (defautl)
+log = { workspace = true, optional = true  }
+env_logger = { workspace = true, optional = true }
+
+# For feature tracing
+tracing = { workspace = true, optional = true  }
+tracing-subscriber = { workspace = true, optional = true  }
+
 [dev-dependencies]
 aws-sdk-dynamodb = { workspace = true }
+
+[features]
+default = ["env_logger"]
+env_logger = ["dep:log", "dep:env_logger"]
+tracing = ["dep:tracing", "dep:tracing-subscriber"]

--- a/lambda-appsync/Cargo.toml
+++ b/lambda-appsync/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lambda-appsync-proc = { path = "../lambda-appsync-proc" }
+lambda-appsync-proc = { path = "../lambda-appsync-proc", default-features = false }
 tokio = { workspace = true }
 lambda_runtime = { workspace = true }
 aws-config = { workspace = true }
@@ -36,5 +36,5 @@ aws-sdk-dynamodb = { workspace = true }
 
 [features]
 default = ["env_logger"]
-env_logger = ["dep:log", "dep:env_logger"]
-tracing = ["dep:tracing", "dep:tracing-subscriber"]
+env_logger = ["dep:log", "dep:env_logger", "lambda-appsync-proc/env_logger"]
+tracing = ["dep:tracing", "dep:tracing-subscriber", "lambda-appsync-proc/tracing"]

--- a/lambda-appsync/src/lib.rs
+++ b/lambda-appsync/src/lib.rs
@@ -108,10 +108,11 @@ pub use serde;
 pub use serde_json;
 pub use tokio;
 
+#[cfg(feature = "log")]
+pub use log;
+
 #[cfg(feature = "env_logger")]
 pub use env_logger;
-#[cfg(feature = "env_logger")]
-pub use log;
 
 #[cfg(feature = "tracing")]
 pub use tracing;

--- a/lambda-appsync/src/lib.rs
+++ b/lambda-appsync/src/lib.rs
@@ -103,12 +103,20 @@ pub use lambda_appsync_proc::appsync_operation;
 
 // Re-export crates that are mandatory for the proc_macro to succeed
 pub use aws_config;
-pub use env_logger;
 pub use lambda_runtime;
-pub use log;
 pub use serde;
 pub use serde_json;
 pub use tokio;
+
+#[cfg(feature = "env_logger")]
+pub use env_logger;
+#[cfg(feature = "env_logger")]
+pub use log;
+
+#[cfg(feature = "tracing")]
+pub use tracing;
+#[cfg(feature = "tracing")]
+pub use tracing_subscriber;
 
 /// Authorization strategy for AppSync operations.
 ///


### PR DESCRIPTION
# Pull Request

## Description
Please include a summary of the changes and which issue is being fixed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Testing
The test suite ran successfully.
Tests had been added for the new log_init feature.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

## Additional Notes

Breaking change: the lambda payload and AppsyncEvent will no longer be logged by default.
